### PR TITLE
Add compare model scores shell

### DIFF
--- a/src/mds_2025_helper_functions/scores.py
+++ b/src/mds_2025_helper_functions/scores.py
@@ -1,0 +1,32 @@
+def compare_model_scores(*args, X, y=None, scoring=None, return_train_scores=False, **kwargs):
+    """Creates a table comparing mean CV scores of multiple models.
+    Parameters
+    ----------
+    *args: model objects implementing 'fit'
+        The model objects to compare
+    
+    X: {array-like, sparse matrix} of shape (n_samples, n_features)
+        Training data
+    
+    y: array-like of shape (n_samples) or (n_samples, n_outputs), default=None
+        Target values to try to predict in the case of supervised learning.
+
+    scoring: str, callable, list, tuple, or dict, default=None
+        Metrics to evaluate models on
+
+    return_train_scores: bool, default=False
+        Whether to include training scores in addition to test scores
+
+    **kwargs:
+        Additional arguments passed to sklearn.model_selection_metrics.cross_validate
+        See https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html
+    
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe comparing model performance with:
+        - Rows: Different models
+        - Columns: Score metrics
+        - Index: Model names
+    """
+    return


### PR DESCRIPTION
Compared to the pkg tutorial from our individual assignment that has 3 functions in the same pycounts.py script, we should have 4 separate scripts, one for each of our functions to reduce the merge conflicts of having all 4 functions in the same script.

To do this I removed the default mds-2025-helper-functions.py script, and added one for the compare_model_scores() function called scores.py

the __init__.py script already coordinates importing all scripts so mds-2025-helper-functions.py was redundent.